### PR TITLE
fix: add try-import to the end of .bazelrc

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,9 +1,10 @@
-# Add your local user settings to file `user.bazelrc`
-try-import %workspace%/user.bazelrc
-
 # Add project-wide settings below.
 #
 # Adds a bazel registry with my registry first
 build \
   --registry=https://raw.githubusercontent.com/filmil/bazel-registry/main \
   --registry=https://bcr.bazel.build
+
+# Add your local user settings to file `user.bazelrc`
+try-import %workspace%/user.bazelrc
+


### PR DESCRIPTION
This, presumably, allows us to override whatever was written down in .bazelrc.