### PR TITLE
Replace LICENSE sha comments with SPDX license annotation

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,4 +1,3 @@
-# LICENSE sha256: c71d239df91726fc519c6eb72d318ec65820627232b2f796219e87dcf35d0ab4
 # SPDX-License-Identifier: Apache-2.0
 
 load("@bazel_lib//lib:write_source_files.bzl", "write_source_files")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,4 +1,4 @@
-# LICENSE sha265: c71d239df91726fc519c6eb72d318ec65820627232b2f796219e87dcf35d0ab4
+# SPDX-License-Identifier: Apache-2.0
 
 module(
     name = "bazel-go-basic",

--- a/build/BUILD.bazel
+++ b/build/BUILD.bazel
@@ -1,4 +1,4 @@
 # gazelle:ignore
-# LICENSE sha256: c71d239df91726fc519c6eb72d318ec65820627232b2f796219e87dcf35d0ab4
+# SPDX-License-Identifier: Apache-2.0
 
 # Required to have the files in this directory be part of a package.

--- a/test/BUILD.bazel
+++ b/test/BUILD.bazel
@@ -1,4 +1,4 @@
-# LICENSE sha256: c71d239df91726fc519c6eb72d318ec65820627232b2f796219e87dcf35d0ab4
+# SPDX-License-Identifier: Apache-2.0
 
 load("@rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 load("@rules_pkg//pkg:zip.bzl", "pkg_zip")

--- a/test/main.go
+++ b/test/main.go
@@ -1,4 +1,4 @@
-// LICENSE sha256: c71d239df91726fc519c6eb72d318ec65820627232b2f796219e87dcf35d0ab4
+// SPDX-License-Identifier: Apache-2.0
 
 package main
 

--- a/test/main_test.go
+++ b/test/main_test.go
@@ -1,4 +1,4 @@
-// LICENSE sha256: c71d239df91726fc519c6eb72d318ec65820627232b2f796219e87dcf35d0ab4
+// SPDX-License-Identifier: Apache-2.0
 
 package main
 


### PR DESCRIPTION
This PR replaces all old `LICENSE sha...` comments with the standard SPDX annotation for Apache 2.0.

- Replaces `# LICENSE sha...` with `# SPDX-License-Identifier: Apache-2.0` in `.bazel` files.
- Replaces `// LICENSE sha...` with `// SPDX-License-Identifier: Apache-2.0` in `.go` files.
- Applies changes to `MODULE.bazel`, `BUILD.bazel`, `test/BUILD.bazel`, `build/BUILD.bazel`, `test/main.go`, and `test/main_test.go`.

This pull request has been created by an automated coding assistant,
with human supervision.

Prompt:
new pr; remove all LICENSE SHA comments from all files where they appear. replace with SPDX license annotation for Apache 2.0 license. send pr